### PR TITLE
support GCP CDN

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -17,7 +17,7 @@ if ENV['S3_ENABLED'] == 'true'
   Paperclip::Attachment.default_options[:url]            = ':s3_domain_url'
   Paperclip::Attachment.default_options[:s3_host_name]   = ENV.fetch('S3_HOSTNAME') { "s3-#{ENV.fetch('S3_REGION')}.amazonaws.com" }
   Paperclip::Attachment.default_options[:path]           = '/:class/:attachment/:id_partition/:style/:filename'
-  Paperclip::Attachment.default_options[:s3_headers]     = { 'Cache-Control' => 'max-age=315576000' }
+  Paperclip::Attachment.default_options[:s3_headers]     = { 'Cache-Control' => 'public, max-age=315576000, immutable' }
   Paperclip::Attachment.default_options[:s3_permissions] = ENV.fetch('S3_PERMISSION') { 'public-read' }
   Paperclip::Attachment.default_options[:s3_region]      = ENV.fetch('S3_REGION') { 'us-east-1' }
 


### PR DESCRIPTION
GCP CDN needs to specify `Cache-Control: public` to enable edge caching.